### PR TITLE
Implement the plugin with `thrift` CLI as a backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+
+.idea

--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
 # sbt-scrooge-typescript
+
+An SBT plugin to generate javascript and typescript definition from thrift files. 
+
+It leverages Twitter's Scrooge plugin to resolve thrift dependencies, and calls the `thrift` command line.
+
+## Why
+
+The Guardian already uses Scrooge to generate scala classes from thrift files, and we also heavily relies on Scrooge to model the dependencies between projects (thrift files are published to maven).
+
+We're now using typescript more and more, so the intent of this plugin is to allow us to hit the ground running and keep our project structure.
+
+## How
+
+This plugin depends on the Scrooge SBT plugin. The dependency resolution and jar unpacking is left to the scrooge plugin. Once these steps are done, the sbt-scrooge-typescript plugin builds the `thrift` command line with the correct parameters in order to generate the typescript files with the correct imports.
+
+## Limits
+
+This plugin relies on the user having the `thrift` CLI installed on their machine. The `thrift` CLI does have a few issues:
+
+ - Dependencies are modeled with "Episode" files in a process called "Episodic compilation". Aside from a pull request and reading the code this isn't documented.
+ - It's harder to ensure the CLI version and the plugin version remain aligned as they are installed separately. It's not impossible to be faced with an issue in the future if the CLI introduce breaking changes.
+ - Namespace is done at the file name level rather than the full path. So if you have one file called `shared.thrift` in one of your dependencies, and `src/thrift/someFolder/shared.thrift` in your project you will have a name collision. So we have to ensure no two files are named the same across our whole dependency tree.
+ - The thrift CLI has a stricter set of reserved words that Scrooge doesn't have. For instance Scrooge is perfectly happy with naming a property `from`, but the `thrift` CLI will raise a compilation error.
+
+## Going forward
+
+We should probably use a proper json library to generate the package.json, something like uPickle would be appropriate.
+
+I'd like to see this plugin generate the typescript source code directly rather than relying on the thrift command line. Scrooge has already got a few nice examples of code generation in scala using Mustache for templating. However upon investigation it turned out to be a larger piece of work than we could allocate for.
+
+So if anyone's keen on extending this plugin, PRs welcome! 
+
+## Usage
+
+You need the following installed and configured:
+ - tsc
+ - npm
+ - thrift
+
+_Assuming your project is already set up with scrooge to generate scala files_
+
+In `project/plugins.sbt`
+```sbt
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.0.0") // latest version here
+```
+
+In `build.sbt`
+```sbt
+enablePlugins(ScroogeTypescriptGen)
+scroogeTypescriptNpmPackageName := "@guardian/mymodule",
+scroogeTypescriptPackageLicense := "Apache-2.0"
+```
+
+Then you're ready to generate and compile your models
+```sbtshell
+compile
+```
+
+You can control more finely what part of the generation is triggered with the following tasks:
+
+ - scroogeTypescriptGenEpisodeFiles: Generates the episode files (files that model the dependencies between each thrift module)
+ - scroogeTypescriptGenTypescript: Generates the typescript files using the `thrift` CLI
+ - scroogeTypescriptGenPackageJson: Generates the `package.json`
+ - scroogeTypescriptGenNPMPackage: Generates the typescript, package.json and copy the README.md (if any)
+ - scroogeTypescriptCompile: Runs `npm install` and `tsc` to check the generated files are compiling
+ - scroogeTypescriptNPMPublish: Runs `npm publish --access public` to publish the package on NPM
+ 
+Here are some settings you may want to use:
+ 
+ - scroogeTypescriptNpmPackageName: The name of the package in `package.json`
+ - scroogeTypescriptPackageLicense: The license of the package on NPM
+ - scroogeTypescriptDevDependencies: The dev dependencies to put in the `package.json`
+ - scroogeTypescriptDependencies: The dependencies to put in the `package.json`
+ - scroogeTypescriptDryRun: To be able to run everything without publishing to NPM
+ 

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,8 @@
+name := "sbt-scrooge-typescript"
+organization := "com.gu"
+
+scalaVersion := "2.12.11"
+
+sbtPlugin := true
+
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
+++ b/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
@@ -1,0 +1,214 @@
+package com.gu.thrift
+
+import com.twitter.scrooge.ScroogeSBT.autoImport.{scroogeThriftSourceFolder, scroogeUnpackDeps}
+import sbt.Keys.{baseDirectory, description, name, sLog, scmInfo, target, version, compile, resourceGenerators}
+import sbt.io.IO
+import sbt._
+
+import scala.sys.process.Process
+
+object ScroogeTypescriptGen extends AutoPlugin {
+
+  object autoImport {
+
+    // the tasks intended for most projects
+    lazy val scroogeTypescriptCompile = taskKey[Unit]("Use the tsc command line to compile the generated files. This would spot any issue in the generated files")
+    lazy val scroogeTypescriptNPMPublish = taskKey[Unit]("Use the tsc command line to compile the generated files. This would spot any issue in the generated files")
+
+    // the tasks intended for the intrepid debuggers
+    lazy val scroogeTypescriptGenPackageJson = taskKey[File]("Generate the package.json file")
+    lazy val scroogeTypescriptGenTypescript = taskKey[Seq[File]]("Run the thrift command line")
+    lazy val scroogeTypescriptGenEpisodeFiles = taskKey[Seq[File]]("Generates the list of episode files from the dependencies resolved by scrooge")
+    lazy val scroogeTypescriptGenNPMPackage = taskKey[Seq[File]]("Generate the npm package")
+
+    // the settings to customise the generation process
+    lazy val scroogeTypescriptDevDependencies = settingKey[Map[String, String]]("The node devDependencies to include in the package.json")
+    lazy val scroogeTypescriptDependencies = settingKey[Map[String, String]]("The node dependencies to include in the package.json")
+    lazy val scroogeTypescriptPackageDirectory = settingKey[File]("The directory where the node package will be generated")
+    lazy val scroogeTypescriptPackageLicense = settingKey[String]("The license used to publish the package")
+    lazy val scroogeTypescriptThriftGenOptions = settingKey[Seq[String]]("The list of generation options passed to the thrift cmd line")
+    lazy val scroogeTypescriptPackageMapping = settingKey[Map[String, String]]("The mapping between the thrift jar dependency name to the npm module name")
+    lazy val scroogeTypescriptNpmPackageName = settingKey[String]("The name of the package in the package.json")
+    lazy val scroogeTypescriptDryRun = settingKey[Boolean]("Whether to try all the step without actually publishing the library on NPM")
+  }
+
+  import autoImport._
+
+  private def runCmd(cmd: String, dir: File, logger: Logger, expected: Int = 0, onError: String): Int = {
+    logger.info(s"Running ${cmd}")
+    val npmReturnCode = Process(cmd, dir).!
+    if (npmReturnCode != expected) {
+      throw new Exception("Unable to install npm dependencies")
+    }
+    npmReturnCode
+  }
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    scroogeTypescriptDevDependencies := Map("typescript" -> "^3.8.3"),
+    scroogeTypescriptDependencies := Map(
+      "@types/node-int64" -> "^0.4.29",
+      "@types/thrift" -> "^0.10.9",
+      "node-int64" -> "^0.4.0",
+      "thrift" -> "^0.13.0"
+    ),
+    scroogeTypescriptPackageDirectory := target.value / "typescript",
+    scroogeTypescriptThriftGenOptions := Seq("ts", "node", "es6"),
+    scroogeTypescriptPackageMapping := Map(),
+    scroogeTypescriptNpmPackageName := name.value,
+    scroogeTypescriptDryRun := false,
+
+
+    scroogeTypescriptGenPackageJson := {
+      def asHash(map: Map[String, String]): String = map.map {case (k, v) => s""""$k": "$v"""" }.mkString("{\n",",\n","\n}")
+
+      sLog.value.info("Generating package.json")
+      val packageJson = scroogeTypescriptPackageDirectory.value / "package.json"
+      val content = s"""
+        |{
+        |  "name": "${scroogeTypescriptNpmPackageName.value}",
+        |  "version": "${version.value}",
+        |  "description": "${description.value}",
+        |  "repository": {
+        |    "type": "git",
+        |    "url": "${scmInfo.value.map(_.browseUrl.toString).getOrElse("")}"
+        |  },
+        |  "author": "",
+        |  "license": "${scroogeTypescriptPackageLicense.value}",
+        |  "devDependencies": ${asHash(scroogeTypescriptDevDependencies.value)},
+        |  "dependencies": ${asHash(scroogeTypescriptDependencies.value)}
+        |}""".stripMargin
+      IO.write(packageJson, content)
+      packageJson
+    },
+
+
+    scroogeTypescriptGenEpisodeFiles := {
+      // If you're wondering what are episode files:
+      // They are flat files consumed by the thrift command line, each line represents a potential javascript dependency
+      // On each line there are two parts delimited by `:`
+      // On the left of the `:` is the name of the thrift file
+      // On the right of the `:` is the path to the npm package
+      // This isn't well documented, I had to read the C source files to understand
+      (Compile / scroogeUnpackDeps).value.map { dependency =>
+        sLog.value.info(s"Generating the episode file for ${dependency.name}")
+        val npmModuleName = scroogeTypescriptPackageMapping.value.getOrElse(dependency.name, dependency.name)
+
+        val episodeFileContent = (dependency ** "*.thrift").get().map { thriftFile =>
+          val cleanedName = thriftFile.name.replaceAll(""".thrift$""", "")
+          // The thrift command line only allow npm dependencies without prefix.
+          // Using the `..` is a way to work around their limitation so npmModuleName can be prefixed with @guardian/...
+          s"${cleanedName}_types:../$npmModuleName/${cleanedName}_types"
+        }.mkString("\n")
+
+        val episodeDirectory = target.value / "episodes" / npmModuleName
+        val episodeFile = episodeDirectory / "thrift.js.episode"
+        IO.write(episodeFile, episodeFileContent)
+        episodeDirectory
+      }
+    },
+
+
+    scroogeTypescriptGenTypescript := {
+      val log = sLog.value
+
+      val outputDirOption = s"-out ${scroogeTypescriptPackageDirectory.value}"
+      IO.createDirectory(scroogeTypescriptPackageDirectory.value)
+
+      val episodeFileOption = Some(scroogeTypescriptGenEpisodeFiles.value)
+        .filter(_.nonEmpty)
+        .map(_.mkString("imports=", ":", ""))
+        .toSeq
+
+      val generationOptions = (scroogeTypescriptThriftGenOptions.value ++ episodeFileOption ).mkString("--gen js:", ",", "")
+
+      val importDirectoriesOptions = (Compile / scroogeUnpackDeps).value.map { dependency =>
+        s"-I ${dependency.getPath}"
+      }.mkString(" ")
+
+      val appsRenderingFiles = (Compile / scroogeThriftSourceFolder).value ** "*.thrift"
+      val returnCodes = appsRenderingFiles.get().map(thriftFile => {
+        val cmdline = s"thrift ${generationOptions} ${importDirectoriesOptions} ${outputDirOption} ${thriftFile.getPath}"
+        log.info(s"Generating definitions for ${thriftFile.getName}")
+        log.info(cmdline)
+        Process(cmdline, baseDirectory.value).!
+      })
+
+      if (returnCodes.sum != 0) {
+        throw new Exception("Error during thrift compilation, check the output above")
+      }
+
+      val definitions = scroogeTypescriptPackageDirectory.value * "*.d.ts"
+      val js = scroogeTypescriptPackageDirectory.value * "*.js"
+      (definitions +++ js).get
+    },
+
+
+    scroogeTypescriptGenNPMPackage := {
+      val generatedSources = scroogeTypescriptGenTypescript.value
+      val generatedPackageJson = scroogeTypescriptGenPackageJson.value
+
+      val readmeFrom = baseDirectory.value / "README.md"
+      val readmeTo = scroogeTypescriptPackageDirectory.value / "README.md"
+      val generatedReadme = {
+        if (readmeFrom.exists()) {
+          IO.copyFile(readmeFrom, readmeTo)
+          Seq(readmeTo)
+        } else {
+          Nil
+        }
+      }
+
+      val message =
+        s"""
+          |
+          |The NPM package ${scroogeTypescriptNpmPackageName.value} has been generated.
+          |
+          |To check it compiles correctly
+          |cd ${scroogeTypescriptPackageDirectory.value}
+          |npm install
+          |tsc --init
+          |tsc
+          |
+          |To publish the package:
+          |npm publish --access public
+          |""".stripMargin
+
+      sLog.value.info(message)
+      generatedSources ++ generatedReadme :+ generatedPackageJson
+    },
+
+    Compile / resourceGenerators += scroogeTypescriptGenNPMPackage,
+
+    scroogeTypescriptCompile := {
+      scroogeTypescriptGenNPMPackage.value
+      val logger: Logger = sLog.value
+      val packageDir = scroogeTypescriptPackageDirectory.value
+
+      runCmd("npm install", packageDir, logger = logger, onError = "Unable to install npm dependencies")
+
+      if (!(packageDir / "tsconfig.json").exists()) {
+        runCmd("tsc --init", packageDir, logger = logger, onError = "Unable to initialise the typescript compiler")
+      }
+
+      runCmd("tsc", packageDir, logger = logger, onError = "There are compilation errors, check the output above")
+    },
+
+    compile := ((compile in Compile) dependsOn scroogeTypescriptCompile).value,
+
+    scroogeTypescriptNPMPublish := {
+      scroogeTypescriptCompile.value
+
+      if (scroogeTypescriptDryRun.value) {
+        sLog.value.info("Would have run npm publish --access public but we're in dry-mode")
+      } else {
+        runCmd(
+          cmd = "npm publish --access public",
+          dir = scroogeTypescriptPackageDirectory.value,
+          logger = sLog.value,
+          onError = "Unable to publish package to NPM, check the output above"
+        )
+      }
+    }
+  )
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
The Guardian already uses Scrooge to generate scala classes from thrift files, and we also heavily relies on Scrooge to model the dependencies between projects (thrift files are published to maven).

We're now using typescript more and more, so the intent of this plugin is to allow us to hit the ground running and keep our project structure.

I have tested it locally and it seems to work. Next step is to publish  this plugin and start using it in CAPI's projects